### PR TITLE
Patch .gitignore for xcode (IDE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,13 @@ docker/*
 
 # macOS
 .DS_Store
+*/.DS_Store
+.*/*/.DS_Store
 
 # IDE
 .idea
 *.iml
+*.xcworkspace
+*.xcworkspace/*
+*.xcodeproj
+*.xcodeproj/*


### PR DESCRIPTION
Minor improvement to `.gitignore` to ignore Xcode IDE files and an edge-case for recursively linked `.DS_Store` files.